### PR TITLE
Configure electron-builder to produce portable executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder"
+    "build": "electron-builder --win portable"
   },
   "devDependencies": {
     "electron": "^28.3.1",
@@ -22,6 +22,16 @@
     ],
     "directories": {
       "output": "dist"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- configure the build script to call electron-builder with the Windows portable target
- add an electron-builder Windows target definition for the portable x64 artifact

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ccd681721883278d268ec57452c7b8