### PR TITLE
Implement adaptive icon extraction and logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 12px;
     padding: 8px;
     border-radius: inherit;
     cursor: pointer;
@@ -297,17 +297,73 @@
     background: rgba(255, 255, 255, 0.1);
   }
 
-  .app-item-content::before {
-    content: '📱';
-    font-size: 16px;
-    width: 24px;
-    height: 24px;
+  .app-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.1);
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 4px;
+    overflow: hidden;
     flex-shrink: 0;
+    position: relative;
+  }
+
+  .app-icon.is-missing {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .app-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: none;
+  }
+
+  .app-icon.has-image img {
+    display: block;
+  }
+
+  .app-icon-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 18px;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
+
+  .app-icon.has-image .app-icon-placeholder {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .app-icon .icon-spinner {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: rgba(255, 255, 255, 0.9);
+    animation: spin 0.8s linear infinite;
+    display: none;
+  }
+
+  .app-icon.is-loading .icon-spinner {
+    display: block;
+  }
+
+  .app-icon.is-loading img {
+    opacity: 0;
+  }
+
+  .app-icon.is-loading .app-icon-placeholder {
+    opacity: 0.4;
+    visibility: visible;
   }
 
   .app-label {
@@ -594,6 +650,39 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function applyIconState(iconWrapper, app) {
+    if (!iconWrapper || !app) return;
+    const img = iconWrapper.querySelector('[data-role="app-icon-image"]');
+    const placeholder = iconWrapper.querySelector('.app-icon-placeholder');
+    const spinner = iconWrapper.querySelector('[data-role="icon-spinner"]');
+    const hasIcon = Boolean(app.iconPath);
+    const loading = Boolean(app.iconLoading) && !hasIcon;
+
+    if (img) {
+      if (hasIcon) {
+        if (img.src !== app.iconPath) {
+          img.src = app.iconPath;
+        }
+      } else {
+        img.removeAttribute('src');
+      }
+      img.style.display = hasIcon ? 'block' : 'none';
+    }
+
+    if (placeholder) {
+      placeholder.style.opacity = hasIcon ? '0' : '1';
+      placeholder.style.visibility = hasIcon ? 'hidden' : 'visible';
+    }
+
+    if (spinner) {
+      spinner.style.display = loading ? 'block' : 'none';
+    }
+
+    iconWrapper.classList.toggle('has-image', hasIcon);
+    iconWrapper.classList.toggle('is-missing', !hasIcon);
+    iconWrapper.classList.toggle('is-loading', loading);
+  }
+
   // Función para crear elementos de app
   function createItem(app) {
     const pkg = app.package;
@@ -606,6 +695,26 @@ window.addEventListener('DOMContentLoaded', () => {
     const content = document.createElement('div');
     content.className = 'app-item-content';
     li.appendChild(content);
+
+    const iconWrapper = document.createElement('div');
+    iconWrapper.className = 'app-icon';
+    iconWrapper.setAttribute('data-role', 'app-icon');
+    const iconImg = document.createElement('img');
+    iconImg.setAttribute('data-role', 'app-icon-image');
+    iconImg.alt = '';
+    iconImg.decoding = 'async';
+    iconImg.loading = 'lazy';
+    iconWrapper.appendChild(iconImg);
+    const iconPlaceholder = document.createElement('div');
+    iconPlaceholder.className = 'app-icon-placeholder';
+    iconPlaceholder.textContent = '📱';
+    iconWrapper.appendChild(iconPlaceholder);
+    const iconSpinner = document.createElement('div');
+    iconSpinner.className = 'icon-spinner';
+    iconSpinner.setAttribute('data-role', 'icon-spinner');
+    iconWrapper.appendChild(iconSpinner);
+    content.appendChild(iconWrapper);
+    applyIconState(iconWrapper, app);
 
     const nameSpan = document.createElement('span');
     nameSpan.className = 'app-label';
@@ -744,7 +853,67 @@ window.addEventListener('DOMContentLoaded', () => {
           return app;
         });
         if (!found) {
-          allPackages.push({ package: pkg, name: label, hasLabel: success, labelResolved: true, processing: false });
+          allPackages.push({ package: pkg, name: label, hasLabel: success, labelResolved: true, processing: false, iconPath: '', iconResolved: false, iconLoading: false });
+        }
+        const previousScroll = allList.scrollTop;
+        renderLists(allPackages);
+        allList.scrollTop = previousScroll;
+      });
+    }
+
+    if (typeof launcher.onPackageIconStarted === 'function') {
+      launcher.onPackageIconStarted(pkg => {
+        const target = typeof pkg === 'string' ? pkg.trim() : '';
+        if (!target) return;
+        let needsRerender = false;
+        allPackages = allPackages.map(app => {
+          if (app.package === target) {
+            if (!app.iconLoading || app.iconPath) {
+              needsRerender = true;
+            }
+            return { ...app, iconLoading: true };
+          }
+          return app;
+        });
+        if (needsRerender) {
+          const previousScroll = allList.scrollTop;
+          renderLists(allPackages);
+          allList.scrollTop = previousScroll;
+        }
+      });
+    }
+
+    if (typeof launcher.onPackageIconUpdated === 'function') {
+      launcher.onPackageIconUpdated(data => {
+        const pkg = data && typeof data.package === 'string' ? data.package.trim() : '';
+        if (!pkg) return;
+        const iconPath = data && typeof data.iconPath === 'string' ? data.iconPath : '';
+        const success = Boolean(data && data.success);
+        let found = false;
+        allPackages = allPackages.map(app => {
+          if (app.package === pkg) {
+            found = true;
+            const resolved = success && Boolean(iconPath);
+            return {
+              ...app,
+              iconPath: resolved ? iconPath : '',
+              iconResolved: resolved,
+              iconLoading: false
+            };
+          }
+          return app;
+        });
+        if (!found) {
+          allPackages.push({
+            package: pkg,
+            name: pkg,
+            hasLabel: false,
+            labelResolved: false,
+            processing: false,
+            iconPath: success && iconPath ? iconPath : '',
+            iconResolved: success && Boolean(iconPath),
+            iconLoading: false
+          });
         }
         const previousScroll = allList.scrollTop;
         renderLists(allPackages);
@@ -772,7 +941,10 @@ window.addEventListener('DOMContentLoaded', () => {
           allPackages = packages.map(app => ({
             ...app,
             processing: false,
-            labelResolved: typeof app.labelResolved === 'boolean' ? app.labelResolved : Boolean(app.hasLabel)
+            labelResolved: typeof app.labelResolved === 'boolean' ? app.labelResolved : Boolean(app.hasLabel),
+            iconPath: typeof app.iconPath === 'string' ? app.iconPath : '',
+            iconResolved: typeof app.iconResolved === 'boolean' ? app.iconResolved : Boolean(app.iconPath),
+            iconLoading: false
           }));
           renderLists(allPackages);
           status.textContent = `${deviceLabel} conectado. ${packages.length} aplicaciones disponibles.`;
@@ -782,14 +954,14 @@ window.addEventListener('DOMContentLoaded', () => {
       } else {
         status.textContent = 'Conectado (modo demo)';
         allPackages = [
-          { package: 'com.example.app1', name: 'App Demo 1' },
-          { package: 'com.example.app2', name: 'App Demo 2' },
-          { package: 'com.example.app3', name: 'App Demo 3' },
-          { package: 'com.example.app4', name: 'App Demo 4' },
-          { package: 'com.example.app5', name: 'App Demo 5' },
-          { package: 'com.example.app6', name: 'App Demo 6' },
-          { package: 'com.example.app7', name: 'App Demo 7' },
-          { package: 'com.example.app8', name: 'App Demo 8' }
+          { package: 'com.example.app1', name: 'App Demo 1', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app2', name: 'App Demo 2', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app3', name: 'App Demo 3', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app4', name: 'App Demo 4', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app5', name: 'App Demo 5', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app6', name: 'App Demo 6', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app7', name: 'App Demo 7', iconPath: '', iconResolved: false, iconLoading: false },
+          { package: 'com.example.app8', name: 'App Demo 8', iconPath: '', iconResolved: false, iconLoading: false }
         ];
         renderLists(allPackages);
       }

--- a/main.js
+++ b/main.js
@@ -1,7 +1,8 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
+const { pathToFileURL } = require('url');
 
 const WINDOW_WIDTH = 416;
 const WINDOW_HEIGHT = 600;
@@ -12,14 +13,26 @@ const labelQueue = [];
 const queuedLabelPackages = new Set();
 let isProcessingLabelQueue = false;
 
+const iconQueue = [];
+const queuedIconPackages = new Set();
+let isProcessingIconQueue = false;
+
 const base = process.env.PORTABLE_EXECUTABLE_DIR || path.dirname(process.execPath);
+const ICON_CACHE_DIR = path.join(base, 'IconCache');
+const TEMP_ICON_BASE_DIR = path.join(base, '__tmp_icons');
+const LOG_FILE_PATH = path.join(base, 'command.log');
 const adb = process.platform === 'win32' ? `"${path.join(base, 'adb.exe')}"` : 'adb';
 let cachedAapt2Command = null;
+let cachedTarCommand = null;
 
 let mainWindow = null;
 let currentDevice = '';
 let PREF_PATH = null;
 let appLabelCache = null;
+const packageApkPathCache = new Map();
+const apkEntriesCache = new Map();
+const resourceTableCache = new Map();
+const packageIconCache = new Map();
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -52,15 +65,104 @@ function createWindow() {
   mainWindow.loadFile(path.join(__dirname, 'index.html'));
 }
 
-function run(command) {
+function ensureDirectory(targetPath) {
+  if (!targetPath) return;
+  try {
+    fs.mkdirSync(targetPath, { recursive: true });
+  } catch (error) {
+    console.warn(`No se pudo crear el directorio ${targetPath}:`, error.message);
+  }
+}
+
+function appendToLog(content) {
+  if (!LOG_FILE_PATH) return;
+  try {
+    ensureDirectory(path.dirname(LOG_FILE_PATH));
+    fs.appendFileSync(LOG_FILE_PATH, content, { encoding: 'utf8' });
+  } catch (error) {
+    console.warn('No se pudo escribir en el archivo de log:', error.message);
+  }
+}
+
+function logCommand(command, stdout, stderr) {
+  if (command) {
+    appendToLog(command.endsWith('\n') ? command : `${command}\n`);
+  }
+  if (stdout) {
+    const output = typeof stdout === 'string' ? stdout : stdout.toString('utf8');
+    if (output) {
+      appendToLog(output.endsWith('\n') ? output : `${output}\n`);
+    }
+  }
+  if (stderr) {
+    const errorOutput = typeof stderr === 'string' ? stderr : stderr.toString('utf8');
+    if (errorOutput) {
+      appendToLog(errorOutput.endsWith('\n') ? errorOutput : `${errorOutput}\n`);
+    }
+  }
+}
+
+function run(command, options = {}) {
   return new Promise((resolve, reject) => {
-    exec(command, { cwd: base, windowsHide: true, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+    const execOptions = { cwd: base, windowsHide: true, maxBuffer: 1024 * 1024, ...options };
+    exec(command, execOptions, (error, stdout, stderr) => {
+      try {
+        logCommand(command, stdout, stderr);
+      } catch {
+        // ignore logging errors
+      }
       if (error) {
         const message = stderr && stderr.trim() ? stderr.trim() : error.message;
         reject(new Error(message));
         return;
       }
       resolve(stdout);
+    });
+  });
+}
+
+function runBuffered(command, options = {}) {
+  return new Promise((resolve, reject) => {
+    const spawnOptions = { cwd: base, windowsHide: true, shell: true, ...options };
+    const child = spawn(command, [], spawnOptions);
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout?.on('data', chunk => {
+      stdoutChunks.push(Buffer.from(chunk));
+    });
+
+    child.stderr?.on('data', chunk => {
+      stderrChunks.push(Buffer.from(chunk));
+    });
+
+    child.on('error', error => {
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      try {
+        logCommand(command, stdout, stderr);
+      } catch {
+        // ignore logging errors
+      }
+      reject(error);
+    });
+
+    child.on('close', code => {
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      try {
+        logCommand(command, stdout, stderr);
+      } catch {
+        // ignore logging errors
+      }
+      if (code !== 0) {
+        const errorMessage = stderr.length
+          ? stderr.toString('utf8').trim() || `Proceso terminado con código ${code}`
+          : `Proceso terminado con código ${code}`;
+        reject(new Error(errorMessage));
+        return;
+      }
+      resolve({ stdout, stderr });
     });
   });
 }
@@ -94,6 +196,335 @@ function buildAdbCommand(args, deviceOverride) {
   return `${adb}${deviceSegment} ${args}`;
 }
 
+function normalizeRemotePath(rawPath) {
+  if (!rawPath) return '';
+  const trimmed = rawPath.trim();
+  if (!trimmed) return '';
+  return trimmed.startsWith('package:') ? trimmed.slice('package:'.length).trim() : trimmed;
+}
+
+function parseResourceValue(rawValue) {
+  if (!rawValue) return null;
+  const value = rawValue.trim();
+  if (!value) return null;
+
+  if (value.startsWith('@')) {
+    const withoutAt = value.slice(1);
+    if (/^0x[0-9a-f]+$/i.test(withoutAt)) {
+      return { raw: value, resourceId: withoutAt.toLowerCase() };
+    }
+    const androidPrefixMatch = withoutAt.match(/^android:([\w\.]+)/i);
+    if (androidPrefixMatch) {
+      const remainder = withoutAt.replace(/^android:/i, '');
+      const segments = remainder.split('/');
+      if (segments.length === 2) {
+        return { raw: value, type: segments[0], name: segments[1], android: true };
+      }
+    }
+    const segments = withoutAt.split('/');
+    if (segments.length === 2) {
+      return { raw: value, type: segments[0], name: segments[1] };
+    }
+    return { raw: value };
+  }
+
+  return { raw: value, path: value };
+}
+
+async function fetchPackageApkPaths(pkg) {
+  const sanitized = typeof pkg === 'string' ? pkg.trim() : '';
+  if (!sanitized) return [];
+
+  if (packageApkPathCache.has(sanitized)) {
+    return packageApkPathCache.get(sanitized);
+  }
+
+  const command = buildAdbCommand(`shell pm path ${sanitized}`);
+  let output = '';
+  try {
+    output = await run(command);
+  } catch (error) {
+    console.warn(`No se pudieron obtener los APK de ${sanitized}:`, error.message);
+    packageApkPathCache.set(sanitized, []);
+    return [];
+  }
+
+  const paths = output
+    .split(/\r?\n/)
+    .map(line => normalizeRemotePath(line))
+    .filter(Boolean);
+
+  const unique = Array.from(new Set(paths));
+  packageApkPathCache.set(sanitized, unique);
+  return unique;
+}
+
+async function pullPackageApks(pkg, remotePaths) {
+  const sanitized = typeof pkg === 'string' ? pkg.trim() : '';
+  if (!sanitized) return null;
+
+  const paths = Array.isArray(remotePaths) && remotePaths.length
+    ? remotePaths
+    : await fetchPackageApkPaths(sanitized);
+
+  if (!paths.length) {
+    return null;
+  }
+
+  ensureDirectory(TEMP_ICON_BASE_DIR);
+  const tempDir = path.join(TEMP_ICON_BASE_DIR, sanitized.replace(/[^\w\.\-]+/g, '_'));
+
+  try {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+
+  ensureDirectory(tempDir);
+
+  const pulled = [];
+  for (let index = 0; index < paths.length; index += 1) {
+    const remotePath = normalizeRemotePath(paths[index]);
+    if (!remotePath) continue;
+    const remoteBase = path.basename(remotePath);
+    let fileName = remoteBase || `split_${index}.apk`;
+    if (/base\.apk$/i.test(remoteBase)) {
+      fileName = 'base.apk';
+    }
+    if (pulled.some(item => item.fileName === fileName)) {
+      fileName = `${index}_${fileName}`;
+    }
+    const localPath = path.join(tempDir, fileName);
+    await run(buildAdbCommand(`pull "${remotePath}" "${localPath}"`));
+    pulled.push({ remotePath, localPath, fileName });
+  }
+
+  if (!pulled.length) {
+    return null;
+  }
+
+  pulled.sort((a, b) => {
+    const aBase = a.fileName === 'base.apk' ? 0 : 1;
+    const bBase = b.fileName === 'base.apk' ? 0 : 1;
+    return aBase - bBase;
+  });
+
+  const baseApkEntry = pulled.find(item => item.fileName === 'base.apk')
+    || pulled.find(item => /base\.apk$/i.test(item.remotePath))
+    || pulled[0];
+
+  return {
+    tempDir,
+    apks: pulled,
+    baseApk: baseApkEntry ? baseApkEntry.localPath : null
+  };
+}
+
+async function getApkEntries(apkPath) {
+  if (!apkPath) return [];
+
+  if (apkEntriesCache.has(apkPath)) {
+    return apkEntriesCache.get(apkPath);
+  }
+
+  const tar = getTarCommand();
+  if (!tar) {
+    apkEntriesCache.set(apkPath, []);
+    return [];
+  }
+
+  try {
+    const { stdout } = await runBuffered(`${tar} -tf "${apkPath}"`);
+    const content = stdout.toString('utf8');
+    const entries = content
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean);
+    apkEntriesCache.set(apkPath, entries);
+    return entries;
+  } catch (error) {
+    console.warn(`No se pudo listar el contenido de ${apkPath}:`, error.message);
+    apkEntriesCache.set(apkPath, []);
+    return [];
+  }
+}
+
+function getFormatFromEntry(entryPath) {
+  if (!entryPath) return '';
+  const lower = entryPath.toLowerCase();
+  if (lower.endsWith('.png')) return 'png';
+  if (lower.endsWith('.webp')) return 'webp';
+  if (lower.endsWith('.jpg')) return 'jpg';
+  if (lower.endsWith('.jpeg')) return 'jpeg';
+  if (lower.endsWith('.xml.flat')) return 'xml.flat';
+  if (lower.endsWith('.xml')) return 'xml';
+  if (lower.endsWith('.svg')) return 'svg';
+  return '';
+}
+
+function findResourceEntry(entries, resource, preferredExtensions) {
+  if (!Array.isArray(entries) || !entries.length || !resource) return null;
+
+  const extensions = Array.isArray(preferredExtensions) && preferredExtensions.length
+    ? preferredExtensions
+    : ['.png', '.webp', '.xml', '.xml.flat', '.jpg', '.jpeg'];
+
+  if (resource.path) {
+    const normalized = resource.path.replace(/^\/+/, '');
+    if (entries.includes(normalized)) {
+      return normalized;
+    }
+    const baseName = path.basename(normalized);
+    const match = entries.find(entry => entry.endsWith(`/${baseName}`));
+    if (match) {
+      return match;
+    }
+  }
+
+  const type = resource.type;
+  const name = resource.name;
+  if (type && name) {
+    const baseName = name.replace(/^@/, '');
+    const prefixes = [`res/${type}-`, `res/${type}/`];
+    for (const ext of extensions) {
+      for (const prefix of prefixes) {
+        const match = entries.find(entry => entry.startsWith(prefix) && entry.endsWith(`${baseName}${ext}`));
+        if (match) {
+          return match;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+async function resolveResourceReference(resource, apks, preferredExtensions) {
+  if (!resource) return null;
+
+  let working = { ...resource };
+  if (working.resourceId && !working.type && !working.name) {
+    const resolved = await resolveResourceId(working.resourceId, apks);
+    if (resolved) {
+      working = { ...working, ...resolved };
+    }
+  }
+
+  if (working.android) {
+    return null;
+  }
+
+  for (const apk of apks) {
+    const entries = await getApkEntries(apk.localPath);
+    const match = findResourceEntry(entries, working, preferredExtensions);
+    if (match) {
+      return {
+        apkPath: apk.localPath,
+        entryPath: match,
+        format: getFormatFromEntry(match)
+      };
+    }
+  }
+
+  return null;
+}
+
+async function extractEntryToTemp(apkPath, entryPath, tempDir) {
+  const tar = getTarCommand();
+  if (!tar) {
+    throw new Error('Herramienta tar no disponible');
+  }
+
+  const extractionRoot = path.join(tempDir, '__extract');
+  ensureDirectory(extractionRoot);
+  await run(`${tar} -xf "${apkPath}" "${entryPath}" -C "${extractionRoot}"`);
+  return path.join(extractionRoot, entryPath);
+}
+
+async function copyFileSafe(source, destination) {
+  ensureDirectory(path.dirname(destination));
+  await fs.promises.copyFile(source, destination);
+  return destination;
+}
+
+function extractDrawableFromXml(xmlContent, tagName) {
+  if (!xmlContent || !tagName) return null;
+  const selfClosingPattern = new RegExp(`<${tagName}[^>]*?>`, 'i');
+  const blockPattern = new RegExp(`<${tagName}[^>]*?>[\s\S]*?<\/${tagName}>`, 'i');
+  const combined = xmlContent.match(selfClosingPattern) || xmlContent.match(blockPattern);
+  if (!combined) return null;
+  const segment = combined[0];
+  const attrMatch = segment.match(/android:(?:drawable|src)="([^"]+)"/i)
+    || segment.match(/android:(?:drawable|src)='([^']+)'/i);
+  if (attrMatch) {
+    return attrMatch[1];
+  }
+  return null;
+}
+
+async function convertVectorDrawableToSvg(vectorXmlPath, destinationPath) {
+  ensureDirectory(path.dirname(destinationPath));
+  await run(`npx --yes vector-drawable-svg "${vectorXmlPath}" "${destinationPath}"`);
+  await fs.promises.access(destinationPath, fs.constants.F_OK);
+  const stats = await fs.promises.stat(destinationPath);
+  if (!stats || !stats.size) {
+    throw new Error('El SVG generado está vacío');
+  }
+  return destinationPath;
+}
+
+async function getResourceTable(apkPath) {
+  if (!apkPath) return new Map();
+
+  if (resourceTableCache.has(apkPath)) {
+    return resourceTableCache.get(apkPath);
+  }
+
+  const aapt2 = getAapt2Command();
+  if (!aapt2) {
+    resourceTableCache.set(apkPath, new Map());
+    return resourceTableCache.get(apkPath);
+  }
+
+  try {
+    const output = await run(`${aapt2} dump resources "${apkPath}"`);
+    const table = new Map();
+    output.split(/\r?\n/).forEach(line => {
+      const match = line.match(/resource\s+0x([0-9a-f]+)\s+([^\s:]+)\s*:/i);
+      if (!match) return;
+      const id = match[1].toLowerCase();
+      const typeAndName = match[2];
+      const segments = typeAndName.split('/');
+      if (segments.length !== 2) return;
+      const [type, name] = segments;
+      if (!type || !name) return;
+      table.set(id, { type, name });
+    });
+    resourceTableCache.set(apkPath, table);
+    return table;
+  } catch (error) {
+    console.warn(`No se pudo obtener la tabla de recursos de ${apkPath}:`, error.message);
+    const empty = new Map();
+    resourceTableCache.set(apkPath, empty);
+    return empty;
+  }
+}
+
+async function resolveResourceId(resourceId, apks) {
+  if (!resourceId) return null;
+  const normalized = resourceId.replace(/^@/, '').toLowerCase();
+  if (!normalized) return null;
+
+  for (const apk of apks) {
+    const table = await getResourceTable(apk.localPath);
+    if (table.has(normalized)) {
+      return table.get(normalized);
+    }
+  }
+
+  return null;
+}
+
 function readPrefs() {
   if (!PREF_PATH) return {};
   try {
@@ -107,7 +538,7 @@ function readPrefs() {
 function writePrefs(prefs) {
   if (!PREF_PATH) return;
   try {
-    fs.mkdirSync(path.dirname(PREF_PATH), { recursive: true });
+    ensureDirectory(path.dirname(PREF_PATH));
     fs.writeFileSync(PREF_PATH, JSON.stringify(prefs, null, 2), 'utf8');
   } catch (error) {
     console.error('No se pudieron guardar las preferencias:', error);
@@ -131,6 +562,55 @@ function rememberAppLabel(pkg, label) {
   const prefs = readPrefs();
   prefs[LABEL_CACHE_KEY] = cache;
   writePrefs(prefs);
+}
+
+function getCachedIconPath(pkg) {
+  if (!pkg) return null;
+  if (packageIconCache.has(pkg)) {
+    return packageIconCache.get(pkg);
+  }
+  const candidates = ['.svg', '.png', '.webp', '.jpg', '.jpeg']
+    .map(ext => path.join(ICON_CACHE_DIR, `${pkg}${ext}`));
+  const existing = candidates.find(candidate => {
+    try {
+      return fs.existsSync(candidate);
+    } catch {
+      return false;
+    }
+  });
+  if (existing) {
+    packageIconCache.set(pkg, existing);
+    return existing;
+  }
+  return null;
+}
+
+function iconPathToUrl(iconPath) {
+  if (!iconPath) return '';
+  try {
+    return pathToFileURL(iconPath).href;
+  } catch {
+    return '';
+  }
+}
+
+async function clearCachedIconFiles(pkg, keepPath) {
+  const sanitized = typeof pkg === 'string' ? pkg.trim() : '';
+  if (!sanitized) return;
+  const keepNormalized = keepPath ? path.normalize(keepPath) : null;
+  const candidates = ['.svg', '.png', '.webp', '.jpg', '.jpeg']
+    .map(ext => path.join(ICON_CACHE_DIR, `${sanitized}${ext}`));
+  for (const candidate of candidates) {
+    const normalizedCandidate = path.normalize(candidate);
+    if (keepNormalized && normalizedCandidate === keepNormalized) {
+      continue;
+    }
+    try {
+      await fs.promises.rm(candidate, { force: true });
+    } catch {
+      // ignore deletion errors
+    }
+  }
 }
 
 function emitToRenderer(channel, payload) {
@@ -194,6 +674,68 @@ async function processLabelQueue() {
   }
 }
 
+function queueAppIcons(packages = []) {
+  packages.forEach(pkg => {
+    const normalized = typeof pkg === 'string' ? pkg.trim() : '';
+    if (!normalized) return;
+    if (getCachedIconPath(normalized)) return;
+    if (queuedIconPackages.has(normalized)) return;
+    queuedIconPackages.add(normalized);
+    iconQueue.push(normalized);
+  });
+  void processIconQueue();
+}
+
+async function processIconQueue() {
+  if (isProcessingIconQueue) return;
+  isProcessingIconQueue = true;
+  try {
+    while (iconQueue.length) {
+      const pkg = iconQueue.shift();
+      if (pkg) {
+        queuedIconPackages.delete(pkg);
+      }
+      if (!pkg) continue;
+
+      const cached = getCachedIconPath(pkg);
+      if (cached) {
+        emitToRenderer('package-icon-updated', {
+          package: pkg,
+          iconPath: iconPathToUrl(cached),
+          success: true
+        });
+        continue;
+      }
+
+      emitToRenderer('package-icon-started', pkg);
+
+      let iconPath = null;
+      try {
+        iconPath = await extractIconForPackage(pkg);
+      } catch (error) {
+        console.warn(`No se pudo extraer el icono para ${pkg}:`, error.message);
+      }
+
+      if (iconPath) {
+        const finalPath = getCachedIconPath(pkg) || iconPath;
+        emitToRenderer('package-icon-updated', {
+          package: pkg,
+          iconPath: iconPathToUrl(finalPath),
+          success: true
+        });
+      } else {
+        emitToRenderer('package-icon-updated', {
+          package: pkg,
+          iconPath: '',
+          success: false
+        });
+      }
+    }
+  } finally {
+    isProcessingIconQueue = false;
+  }
+}
+
 function parseLabelFromDump(output) {
   if (!output) return null;
   const lines = output.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
@@ -204,6 +746,37 @@ function parseLabelFromDump(output) {
   const match = target.match(/:'((?:\\'|[^'])*)'/);
   if (!match) return null;
   return match[1].replace(/\\'/g, "'");
+}
+
+function parseApplicationIconLines(output) {
+  if (!output) return [];
+  const lines = output.split(/\r?\n/);
+  const icons = [];
+  lines.forEach(line => {
+    const match = line.match(/^application-icon-(\d+):'(.*)'$/);
+    if (!match) return;
+    const density = Number.parseInt(match[1], 10);
+    const value = match[2];
+    if (!Number.isNaN(density) && value) {
+      icons.push({ density, value });
+    }
+  });
+  return icons;
+}
+
+function selectBestApplicationIcon(icons) {
+  if (!Array.isArray(icons) || !icons.length) return null;
+  let best = icons[0];
+  let bestScore = best.density === 65535 ? Number.MAX_SAFE_INTEGER : best.density;
+  for (let index = 1; index < icons.length; index += 1) {
+    const icon = icons[index];
+    const score = icon.density === 65535 ? Number.MAX_SAFE_INTEGER : icon.density;
+    if (score > bestScore) {
+      best = icon;
+      bestScore = score;
+    }
+  }
+  return best;
 }
 
 function getAapt2Command() {
@@ -225,25 +798,31 @@ function getAapt2Command() {
   return cachedAapt2Command;
 }
 
+function getTarCommand() {
+  if (cachedTarCommand !== null) {
+    return cachedTarCommand;
+  }
+
+  if (process.platform === 'win32') {
+    const systemTar = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe');
+    if (fs.existsSync(systemTar)) {
+      cachedTarCommand = `"${systemTar}"`;
+      return cachedTarCommand;
+    }
+  }
+
+  cachedTarCommand = 'tar';
+  return cachedTarCommand;
+}
+
 async function extractLabelForPackage(pkg) {
   const sanitized = typeof pkg === 'string' ? pkg.trim() : '';
   if (!sanitized) return null;
 
   const tempApkPath = path.join(base, TEMP_APK_NAME);
   try {
-    const pathOutput = await run(buildAdbCommand(`shell pm path ${sanitized}`));
-    const remoteLine = pathOutput
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .filter(Boolean)
-      .find(line => line.includes('base.apk')) ||
-      pathOutput.split(/\r?\n/).map(line => line.trim()).filter(Boolean)[0];
-
-    if (!remoteLine) return null;
-
-    const remotePath = remoteLine.startsWith('package:')
-      ? remoteLine.slice('package:'.length).trim()
-      : remoteLine;
+    const remotePaths = await fetchPackageApkPaths(sanitized);
+    const remotePath = remotePaths.find(entry => /base\.apk$/i.test(entry)) || remotePaths[0];
     if (!remotePath) return null;
 
     try {
@@ -281,6 +860,141 @@ async function extractLabelForPackage(pkg) {
   }
 }
 
+async function extractIconForPackage(pkg) {
+  const sanitized = typeof pkg === 'string' ? pkg.trim() : '';
+  if (!sanitized) return null;
+
+  const aapt2 = getAapt2Command();
+  const tar = getTarCommand();
+  if (!aapt2) {
+    throw new Error('aapt2 no está disponible');
+  }
+  if (!tar) {
+    throw new Error('tar no está disponible');
+  }
+
+  const pulled = await pullPackageApks(sanitized);
+  if (!pulled || !pulled.apks || !pulled.apks.length) {
+    throw new Error('No se pudieron descargar los APK de la aplicación');
+  }
+
+  const { tempDir, apks, baseApk } = pulled;
+  if (!baseApk) {
+    throw new Error('No se encontró el APK base');
+  }
+
+  ensureDirectory(ICON_CACHE_DIR);
+
+  const cleanup = async () => {
+    try {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  };
+
+  try {
+    const badging = await run(`${aapt2} dump badging "${baseApk}"`);
+    const iconEntries = parseApplicationIconLines(badging);
+    const bestIcon = selectBestApplicationIcon(iconEntries);
+    if (!bestIcon) {
+      throw new Error('No se encontró referencia al icono en el APK');
+    }
+
+    const iconResource = parseResourceValue(bestIcon.value);
+    if (!iconResource) {
+      throw new Error('No se pudo interpretar la referencia al icono');
+    }
+
+    const preferredExt = iconResource.path && iconResource.path.toLowerCase().endsWith('.png')
+      ? ['.png']
+      : ['.png', '.webp', '.xml', '.xml.flat'];
+
+    let resolvedIcon = await resolveResourceReference(iconResource, apks, preferredExt);
+    if (!resolvedIcon && iconResource.path) {
+      resolvedIcon = await resolveResourceReference(iconResource, apks, ['.xml', '.xml.flat', '.png', '.webp']);
+    }
+
+    if (!resolvedIcon) {
+      throw new Error('No se pudo localizar el recurso físico del icono');
+    }
+
+    const finalBaseName = `${sanitized}`;
+
+    if (['png', 'webp', 'jpg', 'jpeg'].includes(resolvedIcon.format)) {
+      const extension = resolvedIcon.format;
+      const destination = path.join(ICON_CACHE_DIR, `${finalBaseName}.${extension}`);
+      const extracted = await extractEntryToTemp(resolvedIcon.apkPath, resolvedIcon.entryPath, tempDir);
+      await clearCachedIconFiles(sanitized, destination);
+      await copyFileSafe(extracted, destination);
+      packageIconCache.set(sanitized, destination);
+      return destination;
+    }
+
+    const adaptiveExtracted = await extractEntryToTemp(resolvedIcon.apkPath, resolvedIcon.entryPath, tempDir);
+    let adaptiveXmlPath = adaptiveExtracted;
+    if (resolvedIcon.format === 'xml.flat') {
+      adaptiveXmlPath = path.join(tempDir, 'adaptive_icon.xml');
+      await run(`${aapt2} convert --output-format xml --output "${adaptiveXmlPath}" "${adaptiveExtracted}"`);
+    }
+
+    let adaptiveContent = '';
+    try {
+      adaptiveContent = await fs.promises.readFile(adaptiveXmlPath, 'utf8');
+    } catch (error) {
+      throw new Error('No se pudo leer el XML del icono adaptativo');
+    }
+
+    if (adaptiveContent.includes('<vector')) {
+      const svgDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.svg`);
+      await clearCachedIconFiles(sanitized, svgDestination);
+      await convertVectorDrawableToSvg(adaptiveXmlPath, svgDestination);
+      packageIconCache.set(sanitized, svgDestination);
+      return svgDestination;
+    }
+
+    const foregroundRef = extractDrawableFromXml(adaptiveContent, 'foreground');
+    if (!foregroundRef) {
+      throw new Error('No se encontró el foreground del icono adaptativo');
+    }
+
+    const foregroundResource = parseResourceValue(foregroundRef);
+    if (!foregroundResource) {
+      throw new Error('Referencia al foreground inválida');
+    }
+
+    const resolvedForeground = await resolveResourceReference(foregroundResource, apks, ['.png', '.webp', '.xml', '.xml.flat']);
+    if (!resolvedForeground) {
+      throw new Error('No se pudo resolver el foreground del icono');
+    }
+
+    if (['png', 'webp', 'jpg', 'jpeg'].includes(resolvedForeground.format)) {
+      const extension = resolvedForeground.format;
+      const destination = path.join(ICON_CACHE_DIR, `${finalBaseName}.${extension}`);
+      const extracted = await extractEntryToTemp(resolvedForeground.apkPath, resolvedForeground.entryPath, tempDir);
+      await clearCachedIconFiles(sanitized, destination);
+      await copyFileSafe(extracted, destination);
+      packageIconCache.set(sanitized, destination);
+      return destination;
+    }
+
+    const vectorExtracted = await extractEntryToTemp(resolvedForeground.apkPath, resolvedForeground.entryPath, tempDir);
+    let vectorXmlPath = vectorExtracted;
+    if (resolvedForeground.format === 'xml.flat') {
+      vectorXmlPath = path.join(tempDir, 'foreground_vector.xml');
+      await run(`${aapt2} convert --output-format xml --output "${vectorXmlPath}" "${vectorExtracted}"`);
+    }
+
+    const svgDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.svg`);
+    await clearCachedIconFiles(sanitized, svgDestination);
+    await convertVectorDrawableToSvg(vectorXmlPath, svgDestination);
+    packageIconCache.set(sanitized, svgDestination);
+    return svgDestination;
+  } finally {
+    await cleanup();
+  }
+}
+
 async function listLaunchablePackages() {
   if (!currentDevice) {
     throw new Error('No hay un dispositivo conectado.');
@@ -306,8 +1020,14 @@ async function listLaunchablePackages() {
 
   const cache = getAppLabelCache();
   const missing = [];
+  const missingIcons = [];
   const result = packages.map(pkg => {
     const cachedLabel = cache[pkg];
+    const iconPath = getCachedIconPath(pkg);
+    const iconResolved = Boolean(iconPath);
+    if (!iconResolved) {
+      missingIcons.push(pkg);
+    }
     if (!cachedLabel) {
       missing.push(pkg);
     }
@@ -315,12 +1035,18 @@ async function listLaunchablePackages() {
       package: pkg,
       name: cachedLabel || pkg,
       hasLabel: Boolean(cachedLabel),
-      labelResolved: Boolean(cachedLabel)
+      labelResolved: Boolean(cachedLabel),
+      iconResolved,
+      iconPath: iconResolved ? iconPathToUrl(iconPath) : ''
     };
   });
 
   if (missing.length) {
     queueAppLabels(missing);
+  }
+
+  if (missingIcons.length) {
+    queueAppIcons(missingIcons);
   }
 
   return result;
@@ -387,6 +1113,8 @@ ipcMain.handle('launch-app', async (_event, pkg) => {
 
 app.whenReady().then(() => {
   PREF_PATH = path.join(app.getPath('userData'), 'preferences.json');
+  ensureDirectory(ICON_CACHE_DIR);
+  ensureDirectory(TEMP_ICON_BASE_DIR);
   createWindow();
 
   app.on('activate', () => {

--- a/preload.js
+++ b/preload.js
@@ -17,5 +17,17 @@ contextBridge.exposeInMainWorld('launcher', {
     const subscription = (_event, pkg) => callback(pkg);
     ipcRenderer.on('package-label-started', subscription);
     return () => ipcRenderer.removeListener('package-label-started', subscription);
+  },
+  onPackageIconStarted: (callback) => {
+    if (typeof callback !== 'function') return () => {};
+    const subscription = (_event, pkg) => callback(pkg);
+    ipcRenderer.on('package-icon-started', subscription);
+    return () => ipcRenderer.removeListener('package-icon-started', subscription);
+  },
+  onPackageIconUpdated: (callback) => {
+    if (typeof callback !== 'function') return () => {};
+    const subscription = (_event, payload) => callback(payload);
+    ipcRenderer.on('package-icon-updated', subscription);
+    return () => ipcRenderer.removeListener('package-icon-updated', subscription);
   }
 });


### PR DESCRIPTION
## Summary
- add reusable helpers to ensure directories, capture command output, and log every subprocess invocation next to the executable
- download base and split APKs, resolve adaptive icon foreground resources, convert drawables to SVG/PNG, and cache results in a dedicated IconCache
- expose icon extraction progress over IPC and refresh the renderer to show real icons, placeholders, and loading indicators with the new cache

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd2d634e28832794c46e13abf44f43