### PR TITLE
Fix icon extraction order for tar command

### DIFF
--- a/main.js
+++ b/main.js
@@ -437,7 +437,7 @@ async function extractEntryToTemp(apkPath, entryPath, tempDir) {
 
   const extractionRoot = path.join(tempDir, '__extract');
   ensureDirectory(extractionRoot);
-  await run(`${tar} -xf "${apkPath}" "${entryPath}" -C "${extractionRoot}"`);
+  await run(`${tar} -xf "${apkPath}" -C "${extractionRoot}" "${entryPath}"`);
   return path.join(extractionRoot, entryPath);
 }
 


### PR DESCRIPTION
## Summary
- reorder the tar extraction command so the target directory flag is applied before the entry

## Testing
- PORTABLE_EXECUTABLE_DIR="$PWD" node - <<'NODE' ... (simulated icon queue extraction)


------
https://chatgpt.com/codex/tasks/task_b_68cf4bd4852883279837c3bbe13c1b1f