### PR TITLE
Refine icon extraction flow and spinner state

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,12 +721,11 @@ window.addEventListener('DOMContentLoaded', () => {
     nameSpan.textContent = displayName;
     content.appendChild(nameSpan);
 
-    if (!app.labelResolved) {
-      const spinner = document.createElement('div');
-      spinner.className = 'loading-spinner';
-      spinner.setAttribute('data-role', 'label-spinner');
-      content.appendChild(spinner);
-    }
+    const labelSpinner = document.createElement('div');
+    labelSpinner.className = 'loading-spinner';
+    labelSpinner.setAttribute('data-role', 'label-spinner');
+    labelSpinner.style.display = app.labelLoading ? 'block' : 'none';
+    content.appendChild(labelSpinner);
 
     content.addEventListener('click', async (event) => {
       if (suppressNextClick) {
@@ -738,19 +737,6 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
     return li;
-  }
-
-  function ensureLabelSpinner(listElement, pkg) {
-    if (!listElement || !pkg) return;
-    const match = allPackages.find(app => app.package === pkg);
-    if (match && match.labelResolved) return;
-    const item = listElement.querySelector(`li[data-package="${pkg}"] .app-item-content`);
-    if (!item) return;
-    if (item.querySelector('[data-role="label-spinner"]')) return;
-    const spinner = document.createElement('div');
-    spinner.className = 'loading-spinner';
-    spinner.setAttribute('data-role', 'label-spinner');
-    item.appendChild(spinner);
   }
 
   // Función para lanzar app
@@ -809,6 +795,12 @@ window.addEventListener('DOMContentLoaded', () => {
     applySearchFilter();
   }
 
+  function rerenderPreservingScroll() {
+    const previousScroll = allList.scrollTop;
+    renderLists(allPackages);
+    allList.scrollTop = previousScroll;
+  }
+
   function applySearchFilter() {
     const term = (search.value || '').trim().toLowerCase();
     const items = allList.querySelectorAll('li');
@@ -832,8 +824,35 @@ window.addEventListener('DOMContentLoaded', () => {
       launcher.onPackageLabelStarted(pkg => {
         const target = typeof pkg === 'string' ? pkg.trim() : '';
         if (!target) return;
-        ensureLabelSpinner(allList, target);
-        ensureLabelSpinner(frequentList, target);
+        let requiresRender = false;
+        let found = false;
+        allPackages = allPackages.map(app => {
+          if (app.package === target) {
+            found = true;
+            if (!app.labelLoading) {
+              requiresRender = true;
+            }
+            return { ...app, labelLoading: true };
+          }
+          return app;
+        });
+        if (!found) {
+          allPackages.push({
+            package: target,
+            name: target,
+            hasLabel: false,
+            labelResolved: false,
+            labelLoading: true,
+            processing: false,
+            iconPath: '',
+            iconResolved: false,
+            iconLoading: false
+          });
+          requiresRender = true;
+        }
+        if (requiresRender) {
+          rerenderPreservingScroll();
+        }
       });
     }
 
@@ -843,21 +862,38 @@ window.addEventListener('DOMContentLoaded', () => {
         if (!pkg) return;
         const label = data && typeof data.name === 'string' && data.name.trim() ? data.name.trim() : pkg;
         const success = Boolean(data && data.success);
-        let found = false;
+        let updated = false;
         allPackages = allPackages.map(app => {
           if (app.package === pkg) {
-            found = true;
+            updated = true;
+            const previousName = app.name && app.name.trim() ? app.name : pkg;
+            const resolvedName = success ? label : previousName;
             const hasLabel = success ? true : Boolean(app.hasLabel);
-            return { ...app, name: label, hasLabel, labelResolved: true };
+            const labelResolved = success ? true : Boolean(app.labelResolved);
+            return {
+              ...app,
+              name: resolvedName,
+              hasLabel,
+              labelResolved,
+              labelLoading: false
+            };
           }
           return app;
         });
-        if (!found) {
-          allPackages.push({ package: pkg, name: label, hasLabel: success, labelResolved: true, processing: false, iconPath: '', iconResolved: false, iconLoading: false });
+        if (!updated) {
+          allPackages.push({
+            package: pkg,
+            name: success ? label : pkg,
+            hasLabel: success,
+            labelResolved: success,
+            labelLoading: false,
+            processing: false,
+            iconPath: '',
+            iconResolved: false,
+            iconLoading: false
+          });
         }
-        const previousScroll = allList.scrollTop;
-        renderLists(allPackages);
-        allList.scrollTop = previousScroll;
+        rerenderPreservingScroll();
       });
     }
 
@@ -876,9 +912,7 @@ window.addEventListener('DOMContentLoaded', () => {
           return app;
         });
         if (needsRerender) {
-          const previousScroll = allList.scrollTop;
-          renderLists(allPackages);
-          allList.scrollTop = previousScroll;
+          rerenderPreservingScroll();
         }
       });
     }
@@ -909,15 +943,14 @@ window.addEventListener('DOMContentLoaded', () => {
             name: pkg,
             hasLabel: false,
             labelResolved: false,
+            labelLoading: false,
             processing: false,
             iconPath: success && iconPath ? iconPath : '',
             iconResolved: success && Boolean(iconPath),
             iconLoading: false
           });
         }
-        const previousScroll = allList.scrollTop;
-        renderLists(allPackages);
-        allList.scrollTop = previousScroll;
+        rerenderPreservingScroll();
       });
     }
   }
@@ -941,6 +974,7 @@ window.addEventListener('DOMContentLoaded', () => {
           allPackages = packages.map(app => ({
             ...app,
             processing: false,
+            labelLoading: false,
             labelResolved: typeof app.labelResolved === 'boolean' ? app.labelResolved : Boolean(app.hasLabel),
             iconPath: typeof app.iconPath === 'string' ? app.iconPath : '',
             iconResolved: typeof app.iconResolved === 'boolean' ? app.iconResolved : Boolean(app.iconPath),
@@ -954,14 +988,14 @@ window.addEventListener('DOMContentLoaded', () => {
       } else {
         status.textContent = 'Conectado (modo demo)';
         allPackages = [
-          { package: 'com.example.app1', name: 'App Demo 1', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app2', name: 'App Demo 2', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app3', name: 'App Demo 3', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app4', name: 'App Demo 4', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app5', name: 'App Demo 5', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app6', name: 'App Demo 6', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app7', name: 'App Demo 7', iconPath: '', iconResolved: false, iconLoading: false },
-          { package: 'com.example.app8', name: 'App Demo 8', iconPath: '', iconResolved: false, iconLoading: false }
+          { package: 'com.example.app1', name: 'App Demo 1', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app2', name: 'App Demo 2', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app3', name: 'App Demo 3', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app4', name: 'App Demo 4', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app5', name: 'App Demo 5', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app6', name: 'App Demo 6', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app7', name: 'App Demo 7', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false },
+          { package: 'com.example.app8', name: 'App Demo 8', iconPath: '', iconResolved: false, iconLoading: false, labelLoading: false, labelResolved: false }
         ];
         renderLists(allPackages);
       }


### PR DESCRIPTION
## Summary
- pull the base APK first and attempt to extract raster launcher icons before falling back to adaptive handling, retrying the raster lookup after downloading any remaining splits
- refactor APK pulling so additional splits can be downloaded on demand without redoing prior work
- extract shared icon resolution logic that supports both raster-first and adaptive icon processing
- clean up per-package temp icon directories once an extraction finishes to avoid leftover folders
- track label/icon loading state in the renderer so only the app currently being processed shows a spinner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d101805e7c8327804d78d9f914256c