### PR TITLE
Add adaptive icon composition using Sharp

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,14 @@ const path = require('path');
 const fs = require('fs');
 const { exec, spawn } = require('child_process');
 const { pathToFileURL } = require('url');
+let sharp = null;
+try {
+  // sharp is optional during development but required for adaptive icon composition
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+  sharp = require('sharp');
+} catch (error) {
+  console.warn('La librería sharp no está disponible:', error.message);
+}
 
 const WINDOW_WIDTH = 416;
 const WINDOW_HEIGHT = 600;
@@ -24,6 +32,12 @@ const LOG_FILE_PATH = path.join(base, 'command.log');
 const adb = process.platform === 'win32' ? `"${path.join(base, 'adb.exe')}"` : 'adb';
 let cachedAapt2Command = null;
 let cachedTarCommand = null;
+
+const ANDROID_COLOR_MAP = {
+  transparent: '#00000000',
+  black: '#ff000000',
+  white: '#ffffffff'
+};
 
 let mainWindow = null;
 let currentDevice = '';
@@ -226,6 +240,10 @@ function parseResourceValue(rawValue) {
       return { raw: value, type: segments[0], name: segments[1] };
     }
     return { raw: value };
+  }
+
+  if (isColorValue(value)) {
+    return { raw: value, color: normalizeHexColor(value) };
   }
 
   return { raw: value, path: value };
@@ -457,43 +475,60 @@ async function resolveIconFromApks(pkg, apks, baseApk, tempDir, options = {}) {
     return svgDestination;
   }
 
-  const foregroundRef = extractDrawableFromXml(adaptiveContent, 'foreground');
-  if (!foregroundRef) {
+  const backgroundLayer = await resolveAdaptiveLayerResource(adaptiveContent, 'background', apks, tempDir, finalBaseName);
+  const foregroundLayer = await resolveAdaptiveLayerResource(adaptiveContent, 'foreground', apks, tempDir, finalBaseName);
+
+  if (!foregroundLayer) {
     throw new Error('No se encontró el foreground del icono adaptativo');
   }
 
-  const foregroundResource = parseResourceValue(foregroundRef);
-  if (!foregroundResource) {
-    throw new Error('Referencia al foreground inválida');
+  if (sharp && (backgroundLayer || foregroundLayer)) {
+    const composedDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.png`);
+    try {
+      await clearCachedIconFiles(sanitized, composedDestination);
+      await composeAdaptiveIcon(composedDestination, backgroundLayer, foregroundLayer);
+      packageIconCache.set(sanitized, composedDestination);
+      return composedDestination;
+    } catch (error) {
+      console.warn(`No se pudo componer el icono adaptativo para ${sanitized}:`, error.message);
+    }
   }
 
-  const resolvedForeground = await resolveResourceReference(foregroundResource, apks, ['.png', '.webp', '.xml', '.xml.flat']);
-  if (!resolvedForeground) {
-    throw new Error('No se pudo resolver el foreground del icono');
-  }
-
-  if (rasterExtensions.includes(resolvedForeground.format)) {
-    const extension = resolvedForeground.format;
-    const destination = path.join(ICON_CACHE_DIR, `${finalBaseName}.${extension}`);
-    const extracted = await extractEntryToTemp(resolvedForeground.apkPath, resolvedForeground.entryPath, tempDir);
+  if (foregroundLayer.type === 'raster' && foregroundLayer.path && foregroundLayer.format) {
+    const destination = path.join(ICON_CACHE_DIR, `${finalBaseName}.${foregroundLayer.format}`);
     await clearCachedIconFiles(sanitized, destination);
-    await copyFileSafe(extracted, destination);
+    await copyFileSafe(foregroundLayer.path, destination);
     packageIconCache.set(sanitized, destination);
     return destination;
   }
 
-  const vectorExtracted = await extractEntryToTemp(resolvedForeground.apkPath, resolvedForeground.entryPath, tempDir);
-  let vectorXmlPath = vectorExtracted;
-  if (resolvedForeground.format === 'xml.flat') {
-    vectorXmlPath = path.join(tempDir, 'foreground_vector.xml');
-    await run(`${aapt2} convert --output-format xml --output "${vectorXmlPath}" "${vectorExtracted}"`);
+  if (foregroundLayer.type === 'vector' && foregroundLayer.path) {
+    const svgDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.svg`);
+    await clearCachedIconFiles(sanitized, svgDestination);
+    await copyFileSafe(foregroundLayer.path, svgDestination);
+    packageIconCache.set(sanitized, svgDestination);
+    return svgDestination;
   }
 
-  const svgDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.svg`);
-  await clearCachedIconFiles(sanitized, svgDestination);
-  await convertVectorDrawableToSvg(vectorXmlPath, svgDestination);
-  packageIconCache.set(sanitized, svgDestination);
-  return svgDestination;
+  if (foregroundLayer.type === 'color' && foregroundLayer.color && sharp) {
+    const colorDestination = path.join(ICON_CACHE_DIR, `${finalBaseName}.png`);
+    const rgba = colorStringToRgba(foregroundLayer.color);
+    if (rgba) {
+      await clearCachedIconFiles(sanitized, colorDestination);
+      await sharp({
+        create: {
+          width: 512,
+          height: 512,
+          channels: 4,
+          background: { r: rgba.r, g: rgba.g, b: rgba.b, alpha: rgba.a / 255 }
+        }
+      }).png().toFile(colorDestination);
+      packageIconCache.set(sanitized, colorDestination);
+      return colorDestination;
+    }
+  }
+
+  throw new Error('No se pudo materializar el foreground del icono adaptativo');
 }
 
 async function getApkEntries(apkPath) {
@@ -630,12 +665,216 @@ function extractDrawableFromXml(xmlContent, tagName) {
   const combined = xmlContent.match(selfClosingPattern) || xmlContent.match(blockPattern);
   if (!combined) return null;
   const segment = combined[0];
-  const attrMatch = segment.match(/android:(?:drawable|src)="([^"]+)"/i)
-    || segment.match(/android:(?:drawable|src)='([^']+)'/i);
+  const attrMatch = segment.match(/android:(?:drawable|src|color)="([^"]+)"/i)
+    || segment.match(/android:(?:drawable|src|color)='([^']+)'/i);
   if (attrMatch) {
     return attrMatch[1];
   }
   return null;
+}
+
+function isColorValue(value) {
+  if (!value) return false;
+  const trimmed = value.trim();
+  return /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(trimmed);
+}
+
+function normalizeHexColor(value) {
+  if (!isColorValue(value)) return null;
+  const trimmed = value.trim().slice(1).toLowerCase();
+  if (trimmed.length === 3) {
+    return `#${trimmed.split('').map(ch => `${ch}${ch}`).join('')}`;
+  }
+  if (trimmed.length === 4) {
+    const expanded = trimmed.split('').map(ch => `${ch}${ch}`).join('');
+    return `#${expanded}`;
+  }
+  return `#${trimmed}`;
+}
+
+function colorStringToRgba(color) {
+  if (!color) return null;
+  const normalized = normalizeHexColor(color);
+  if (!normalized) return null;
+  const hex = normalized.slice(1);
+  let alpha = 255;
+  let offset = 0;
+  if (hex.length === 8) {
+    alpha = Number.parseInt(hex.slice(0, 2), 16);
+    offset = 2;
+  } else if (hex.length !== 6) {
+    return null;
+  }
+  const r = Number.parseInt(hex.slice(offset, offset + 2), 16);
+  const g = Number.parseInt(hex.slice(offset + 2, offset + 4), 16);
+  const b = Number.parseInt(hex.slice(offset + 4, offset + 6), 16);
+  return { r, g, b, a: alpha };
+}
+
+async function materializeResolvedResource(resolved, apks, tempDir, options = {}) {
+  if (!resolved) return null;
+  const { apkPath, entryPath, format } = resolved;
+  if (!apkPath || !entryPath || !format) {
+    return null;
+  }
+
+  const suffix = options.suffix || 'layer';
+
+  if (['png', 'webp', 'jpg', 'jpeg'].includes(format)) {
+    const extracted = await extractEntryToTemp(apkPath, entryPath, tempDir);
+    return { type: 'raster', path: extracted, format };
+  }
+
+  let xmlPath = await extractEntryToTemp(apkPath, entryPath, tempDir);
+  if (format === 'xml.flat') {
+    const aapt2 = getAapt2Command();
+    if (!aapt2) {
+      return null;
+    }
+    const convertedPath = path.join(tempDir, `${suffix}.xml`);
+    await run(`${aapt2} convert --output-format xml --output "${convertedPath}" "${xmlPath}"`);
+    xmlPath = convertedPath;
+  }
+
+  let xmlContent = '';
+  try {
+    xmlContent = await fs.promises.readFile(xmlPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  if (/<vector[\s>]/i.test(xmlContent)) {
+    const svgPath = path.join(tempDir, `${suffix}.svg`);
+    await convertVectorDrawableToSvg(xmlPath, svgPath);
+    return { type: 'vector', path: svgPath, format: 'svg' };
+  }
+
+  const nestedTags = ['bitmap', 'item', 'inset'];
+  for (const tag of nestedTags) {
+    const nestedRef = extractDrawableFromXml(xmlContent, tag);
+    if (nestedRef) {
+      const nestedResource = parseResourceValue(nestedRef);
+      if (nestedResource) {
+        const nested = await resolveResourceReference(nestedResource, apks, ['.png', '.webp', '.jpg', '.jpeg', '.xml', '.xml.flat']);
+        if (nested) {
+          return materializeResolvedResource(nested, apks, tempDir, { suffix: `${suffix}_${tag}` });
+        }
+      }
+    }
+  }
+
+  const colorAttrMatch = xmlContent.match(/android:(?:color|value)="([^"]+)"/i)
+    || xmlContent.match(/android:(?:color|value)='([^']+)'/i);
+  if (colorAttrMatch && isColorValue(colorAttrMatch[1])) {
+    return { type: 'color', color: normalizeHexColor(colorAttrMatch[1]), format: 'color' };
+  }
+
+  const colorNodeMatch = xmlContent.match(/<color[^>]*>([^<]+)<\/color>/i);
+  if (colorNodeMatch && isColorValue(colorNodeMatch[1])) {
+    return { type: 'color', color: normalizeHexColor(colorNodeMatch[1]), format: 'color' };
+  }
+
+  return null;
+}
+
+async function resolveAdaptiveLayerResource(adaptiveContent, layerTag, apks, tempDir, baseName) {
+  if (!adaptiveContent || !layerTag) return null;
+  const drawableRef = extractDrawableFromXml(adaptiveContent, layerTag);
+  if (!drawableRef) {
+    return null;
+  }
+  const resource = parseResourceValue(drawableRef);
+  if (!resource) {
+    return null;
+  }
+  if (resource.color) {
+    return { type: 'color', color: resource.color, format: 'color' };
+  }
+  if (resource.android && resource.type === 'color' && resource.name) {
+    const mappedColor = ANDROID_COLOR_MAP[resource.name.toLowerCase()];
+    if (mappedColor) {
+      return { type: 'color', color: normalizeHexColor(mappedColor), format: 'color' };
+    }
+  }
+  const resolved = await resolveResourceReference(resource, apks, ['.png', '.webp', '.jpg', '.jpeg', '.xml', '.xml.flat']);
+  if (!resolved) {
+    return null;
+  }
+  const suffix = `${baseName}_${layerTag}`;
+  const materialized = await materializeResolvedResource(resolved, apks, tempDir, { suffix });
+  if (!materialized) {
+    return null;
+  }
+  return { ...materialized, resource, resolved };
+}
+
+async function composeAdaptiveIcon(destination, backgroundLayer, foregroundLayer) {
+  if (!sharp) {
+    throw new Error('sharp no está disponible');
+  }
+
+  const size = 512;
+  let base = null;
+
+  if (backgroundLayer) {
+    if (backgroundLayer.type === 'color') {
+      const rgba = colorStringToRgba(backgroundLayer.color);
+      const background = rgba
+        ? { r: rgba.r, g: rgba.g, b: rgba.b, alpha: rgba.a / 255 }
+        : { r: 0, g: 0, b: 0, alpha: 0 };
+      base = sharp({
+        create: {
+          width: size,
+          height: size,
+          channels: 4,
+          background
+        }
+      });
+    } else if (backgroundLayer.path) {
+      base = sharp(backgroundLayer.path);
+    }
+  }
+
+  if (!base) {
+    base = sharp({
+      create: {
+        width: size,
+        height: size,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 }
+      }
+    });
+  }
+
+  const composites = [];
+  if (foregroundLayer) {
+    if (foregroundLayer.type === 'color') {
+      const rgba = colorStringToRgba(foregroundLayer.color);
+      if (rgba) {
+        const buffer = await sharp({
+          create: {
+            width: size,
+            height: size,
+            channels: 4,
+            background: { r: rgba.r, g: rgba.g, b: rgba.b, alpha: rgba.a / 255 }
+          }
+        }).png().toBuffer();
+        composites.push({ input: buffer, gravity: 'center' });
+      }
+    } else if (foregroundLayer.path) {
+      composites.push({ input: foregroundLayer.path, gravity: 'center' });
+    }
+  }
+
+  ensureDirectory(path.dirname(destination));
+  await base
+    .resize(size, size, { fit: 'cover' })
+    .ensureAlpha()
+    .composite(composites)
+    .png()
+    .toFile(destination);
+
+  return destination;
 }
 
 async function convertVectorDrawableToSvg(vectorXmlPath, destinationPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "adb-dummy-app",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "sharp": "^0.33.2"
+      },
       "devDependencies": {
         "electron": "^28.3.1",
         "electron-builder": "^26.0.12"
@@ -576,12 +579,383 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -1717,11 +2091,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1734,8 +2120,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2010,7 +2405,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
       "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3143,6 +3537,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-ci": {
       "version": "3.0.1",
@@ -4301,6 +4701,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4330,6 +4781,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -4743,6 +5203,13 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "main.js",
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "sharp": "^0.33.2"
+  },
   "scripts": {
     "start": "electron .",
     "build": "electron-builder --win portable"


### PR DESCRIPTION
## Summary
- add optional sharp dependency and color helpers used during icon extraction
- resolve adaptive icon layers and compose background/foreground assets into cached PNGs with Sharp
- fall back to raster/vector/color outputs when composition is not possible and add the sharp runtime dependency

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_b_68d12eda205c8327b5959312c1bcb956